### PR TITLE
Fix completions

### DIFF
--- a/server/src/nlpserver/comments_extraction_python.scm
+++ b/server/src/nlpserver/comments_extraction_python.scm
@@ -63,4 +63,7 @@
         	(expression_statement (assignment left: (identifier) @lone.identifier))
         )
     )
+
+    ;; all the comments, because lone comments couldn't be filtered
+    (comment) @all_comments
 ])


### PR DESCRIPTION
Attempt to give completion items when new identifier is being written below a comment line.
The implementation is a bit hacky because of lack of proper query for getting incomplete identifiers in tree_sitter for python. So, any first word below the comment is treated as potential identifier.