### PR TITLE
Fix completions

### DIFF
--- a/server/src/nlpserver/convert.py
+++ b/server/src/nlpserver/convert.py
@@ -14,7 +14,7 @@ def set_convention(words: list[str], convention: VariableConventions)->str:
         for word in wordsForVariable:
             variable+=word
     
-    elif convention==VariableConventions.Snakecase:
+    elif convention==VariableConventions.Pascalcase:
         wordsForVariable=[word.title() for word in words]#.insert(0,words[0])
         
         for word in wordsForVariable:
@@ -27,7 +27,7 @@ def set_convention(words: list[str], convention: VariableConventions)->str:
             variable+=word+"-"
         variable=variable[:-1]
 
-    elif convention==VariableConventions.Pascalcase or convention==VariableConventions.Undefined:
+    elif convention==VariableConventions.Snakecase or convention==VariableConventions.Undefined:
         wordsForVariable=[word.lower() for word in words]#.insert(0,words[0])
             
         for word in wordsForVariable:

--- a/server/src/nlpserver/predict_variables.py
+++ b/server/src/nlpserver/predict_variables.py
@@ -64,7 +64,7 @@ def initalize_model(model_name: str = MODEL_NAME, use_local: bool = True):
     TOKENIZER.save_pretrained(model_name, from_pt=True)
 
 
-def get_variable_name(comment: str) -> Optional[str]:
+def get_variable_name(comment: str, **kwargs) -> Optional[str]:
     """
     Returns space separated variable parts if successful else returns None
     """
@@ -84,7 +84,8 @@ def get_variable_name(comment: str) -> Optional[str]:
             max_length=100,
             early_stopping=True,
             use_cache=True,
-            do_sample=True
+            do_sample=True,
+            kwargs=kwargs
         ).to(DEVICE)
 
         output_variable_name = TOKENIZER.decode(

--- a/server/src/nlpserver/server.py
+++ b/server/src/nlpserver/server.py
@@ -53,7 +53,8 @@ from pygls.server import LanguageServer
 
 from collections import defaultdict, Counter
 
-from predict_variables import initalize_model, get_variable_name, MODEL, TOKENIZER
+from predict_variables import initalize_model, get_variable_name
+import predict_variables
 from variable_conventions import VariableConventions, get_convention
 from convert import set_convention
 
@@ -166,13 +167,13 @@ def completions(params: CompletionParams):
             for (start, end) in IDENTIFIER_WITH_POINTS[identifier]:
                 if (current_line_number == start[0]) or (current_line_number == end[0]):
 
-                    if TOKENIZER is not None:
-                        force_words_ids = TOKENIZER(identifier, add_special_tokens=False).input_ids
+                    if predict_variables.TOKENIZER is not None:
+                        force_words_ids = predict_variables.TOKENIZER(identifier, add_special_tokens=False).input_ids
                         
                         # passing the already present incomplete identifier/ not sure if this works
                         var_names = get_variable_name_with_cache(comment, force_regenerate=True, force_words_ids=force_words_ids)
                     else:
-                        var_names = get_variable_name_with_cache(comment)
+                        var_names = get_variable_name_with_cache(comment, force_regenerate=True)
 
                     for var_name in var_names:
                         if var_name is not None:

--- a/server/src/nlpserver/server.py
+++ b/server/src/nlpserver/server.py
@@ -53,7 +53,7 @@ from pygls.server import LanguageServer
 
 from collections import defaultdict, Counter
 
-from predict_variables import initalize_model, get_variable_name
+from predict_variables import initalize_model, get_variable_name, MODEL, TOKENIZER
 from variable_conventions import VariableConventions, get_convention
 from convert import set_convention
 
@@ -75,7 +75,7 @@ COMMENTS_AND_VARIABLE_NAME: dict[str, set[str]] = defaultdict(set)
 FOLLOWED_CONVENTION: VariableConventions = VariableConventions.Undefined
 
 
-def get_variable_name_with_cache(comment: str):
+def get_variable_name_with_cache(comment: str, force_regenerate=False, **kwargs):
     """
     Returns the variable from cache if available if not
     gets the variable name from model
@@ -86,10 +86,10 @@ def get_variable_name_with_cache(comment: str):
         return
 
     # the set keeps one variable name, i.e. whole name not the parts
-    if len(COMMENTS_AND_VARIABLE_NAME[comment]) > 0:
+    if not force_regenerate and len(COMMENTS_AND_VARIABLE_NAME[comment]) > 0:
         variable_set = COMMENTS_AND_VARIABLE_NAME[comment].copy()
     else:
-        var_name = get_variable_name(comment)
+        var_name = get_variable_name(comment, **kwargs)
         variable_set = set()
         if var_name is not None:
 
@@ -165,15 +165,20 @@ def completions(params: CompletionParams):
         for comment in comments:
             for (start, end) in IDENTIFIER_WITH_POINTS[identifier]:
                 if (current_line_number == start[0]) or (current_line_number == end[0]):
-                    
-                    # passing the already present incomplete identifier/ not sure if this works
-                    var_names = get_variable_name_with_cache(comment + " " + identifier)
+
+                    if TOKENIZER is not None:
+                        force_words_ids = TOKENIZER(identifier, add_special_tokens=False).input_ids
+                        
+                        # passing the already present incomplete identifier/ not sure if this works
+                        var_names = get_variable_name_with_cache(comment, force_regenerate=True, force_words_ids=force_words_ids)
+                    else:
+                        var_names = get_variable_name_with_cache(comment)
 
                     for var_name in var_names:
                         if var_name is not None:
                             completion_items.append(
                                 CompletionItem(
-                                    var_name, kind=CompletionItemKind.Variable
+                                    var_name, kind=CompletionItemKind.Keyword, filter_text=identifier # hack for vscode filtering out variable not containing the already typed characters.
                                 )
                             )
 
@@ -199,6 +204,10 @@ def create_warnings(params: DidChangeTextDocumentParams):
         if IDENTIFIER_WITH_COMMENTS[identifer] is not None:
             severity = DiagnosticSeverity.Hint
             variable_name = next(get_variable_name_with_cache(" ".join(IDENTIFIER_WITH_COMMENTS[identifer])), None)
+
+            # don't create hints if it's the same name
+            if variable_name == identifer:
+                continue
 
             if variable_name is not None:
                 message = f"Change to variable name {variable_name}"


### PR DESCRIPTION
Fix completions by including the currently typed incomplete identifier in forced words for the model to generate.
Also, fix the snake and pascal case convention.
Force the newly generated variable name without having to match the initially typed characters.